### PR TITLE
Dockerfile: Updated port, listten addr and base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,12 @@
-FROM mhart/alpine-node:0.10
+FROM mhart/alpine-node:9.8
 MAINTAINER me@gbraad.nl
 
 COPY . /app
-RUN cd /app && npm install
+WORKDIR /app
 
-EXPOSE 4000
-CMD cd /app && node server
+RUN npm install
+
+EXPOSE 8080
+ENV IPADDR=0.0.0.0
+
+CMD node server


### PR DESCRIPTION
- Moved to an up2date alpine base image.
- Set 0.0.0.0 as listen address to work in the container
- Set WORKDIR to get rid of the 'cd' commands.